### PR TITLE
fix: Add LICENSE file and update Discord link in README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+copyright (c) 2025, Everbuild & Contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Join now and explore the vast universe on our Minecraft Server. On our network, 
 
 ## Contributing
 
-Anyone is welcome to contribute to the documentation. If you would like to contribute, please fork the repository and submit a pull request. If you are unsure of how to do this, please contact us on our [Discord](https://discord.gg/NqxhvnhE7V).
+Anyone is welcome to contribute to the documentation. If you would like to contribute, please fork the repository and submit a pull request. If you are unsure of how to do this, please contact us on our [Discord](https://discord.gg/h4Smr5YTnN).
 If you notice any issues with the documentation, please submit an issue on github.
 
 ## Building


### PR DESCRIPTION
Added an MIT license to clearly define the terms of software usage and distribution. Updated the Discord invite link in README to reflect the correct and active URL.